### PR TITLE
Fix for more Devices

### DIFF
--- a/octoprint_roomtemp/__init__.py
+++ b/octoprint_roomtemp/__init__.py
@@ -32,7 +32,7 @@ class RoomTempPlugin(octoprint.plugin.StartupPlugin,
 			# Match a line like 'Hardware   : BCM2709'
 			match = re.search('^Hardware\s+:\s+(\w+)$', cpuinfo, flags=re.MULTILINE | re.IGNORECASE)
 
-			if match.group(1) == 'BCM2708' or match.group(1) == 'BCM2709':
+			if match.group(1) == 'BCM2708' or match.group(1) == 'BCM2709' or match.group(1) == 'BCM2835':
 				self.isRaspi = True
 			else:
 				self.isRaspi = False

--- a/octoprint_roomtemp/__init__.py
+++ b/octoprint_roomtemp/__init__.py
@@ -52,7 +52,7 @@ class RoomTempPlugin(octoprint.plugin.StartupPlugin,
 		os.system('modprobe w1-gpio')
 		os.system('modprobe w1-therm')
 		base_dir = '/sys/bus/w1/devices/'
-		device_folder = glob.glob(base_dir + '28*')[0]
+		device_folder = glob.glob(base_dir + '[0-9][0-9]*')[0]
 		device_file = device_folder + '/w1_slave'
 		if os.path.isfile(device_file):
 			lines = read_temp_raw(device_file)


### PR DESCRIPTION
1. added "BCM2835" hardware detection for Raspberry Pi Model A, B, B+
2. modified folder search to get also the "DS18S20" device family